### PR TITLE
Improve chat response when DB empty

### DIFF
--- a/src/main/java/de/deltatree/tools/rag/config/VectorStoreConfig.java
+++ b/src/main/java/de/deltatree/tools/rag/config/VectorStoreConfig.java
@@ -1,7 +1,6 @@
 package de.deltatree.tools.rag.config;
 
 import org.springframework.ai.embedding.EmbeddingModel;
-import org.springframework.ai.vectorstore.VectorStore;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -12,7 +11,7 @@ import de.deltatree.tools.rag.vectorstore.PostgresVectorStore;
 public class VectorStoreConfig {
 
     @Bean
-    VectorStore vectorStore(
+    PostgresVectorStore vectorStore(
             @Qualifier("ollamaEmbeddingModel") EmbeddingModel embeddingModel,
             DocumentEmbeddingRepository repository) {
         System.out.println("Creating Ollama VectorStore");

--- a/src/main/java/de/deltatree/tools/rag/controller/ChatController.java
+++ b/src/main/java/de/deltatree/tools/rag/controller/ChatController.java
@@ -7,7 +7,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.ai.document.Document;
 import org.springframework.ai.vectorstore.SearchRequest;
-import org.springframework.ai.vectorstore.VectorStore;
+import de.deltatree.tools.rag.vectorstore.PostgresVectorStore;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 
@@ -18,10 +18,10 @@ import java.util.stream.Collectors;
 @RequestMapping("/chat")
 public class ChatController {
     private static final Logger LOG = LoggerFactory.getLogger(ChatController.class);
-    private final VectorStore vectorStore;
+    private final PostgresVectorStore vectorStore;
     private final OllamaService ollamaService;
 
-    public ChatController(VectorStore vectorStore, OllamaService ollamaService) {
+    public ChatController(PostgresVectorStore vectorStore, OllamaService ollamaService) {
         this.vectorStore = vectorStore;
         this.ollamaService = ollamaService;
         LOG.info("ChatController initialized successfully");
@@ -51,6 +51,10 @@ public class ChatController {
 
         // 2. Check if we have relevant context AND if it's actually related to the question
         if (documents.isEmpty()) {
+            long count = vectorStore.getDocumentCount();
+            if (count == 0) {
+                return new Answer("My knowledge base is empty. Please upload documents before asking questions.");
+            }
             return new Answer("I don't have information about that topic in my knowledge base. Please try rephrasing your question or check if relevant documents have been uploaded.");
         }
 


### PR DESCRIPTION
## Summary
- switch VectorStore bean to expose `PostgresVectorStore`
- inject `PostgresVectorStore` into `ChatController`
- return an informative message when the knowledge base is empty

## Testing
- `gradle test`

------
https://chatgpt.com/codex/tasks/task_e_686467f29344832fb37e5ffc89358b5c